### PR TITLE
Fixed crash of exec command in Python 3.5

### DIFF
--- a/mp/mpfshell.py
+++ b/mp/mpfshell.py
@@ -526,6 +526,7 @@ class MpFileShell(cmd.Cmd):
         """
 
         def data_consumer(data):
+            data = str(data.decode('utf-8'))
             sys.stdout.write(data.strip("\x04"))
 
         if not len(args):


### PR DESCRIPTION
In Python 3.5 the exec function (e.g. exec print(1+2)) fails with "a bytes-like object is required, not 'str'" and crashes Mpfshell. The crash is caused by data_consumer - the type of "data".
