### PR TITLE
Fixes: File upload is broken on ESP8266 on newer Micropython /flash issue

### DIFF
--- a/mp/contelnet.py
+++ b/mp/contelnet.py
@@ -42,6 +42,9 @@ class ConTelnet(ConBase):
             self.read = self.__read3
 
         self.tn = telnetlib.Telnet(ip)
+        if user=='':
+            self.fifo = deque()
+            return
 
         if b'Login as:' in self.tn.read_until(b'Login as:', timeout=5.0):
             self.tn.write(bytes(user.encode('ascii')) + b"\r\n")

--- a/mp/mpfexp.py
+++ b/mp/mpfexp.py
@@ -67,7 +67,7 @@ class MpFileExplorer(Pyboard):
         except Exception as e:
             raise ConError(e)
 
-        self.dir = "/"
+        self.dir = "/flash/"
         self.sysname = None
         self.setup()
 
@@ -146,7 +146,7 @@ class MpFileExplorer(Pyboard):
     def close(self):
 
         Pyboard.close(self)
-        self.dir = "/"
+        self.dir = "/flash/"
 
     def teardown(self):
 

--- a/mp/mpfexp.py
+++ b/mp/mpfexp.py
@@ -67,7 +67,7 @@ class MpFileExplorer(Pyboard):
         except Exception as e:
             raise ConError(e)
 
-        self.dir = "/flash/"
+        self.dir = None
         self.sysname = None
         self.setup()
 
@@ -146,7 +146,7 @@ class MpFileExplorer(Pyboard):
     def close(self):
 
         Pyboard.close(self)
-        self.dir = "/flash/"
+        self.dir = None
 
     def teardown(self):
 
@@ -157,6 +157,11 @@ class MpFileExplorer(Pyboard):
 
         self.enter_raw_repl()
         self.exec_("import os, sys, ubinascii")
+
+        # new version mounts files on /flash so lets set dir based on where we are in
+        # filesystem
+        self.dir = self.eval("os.getcwd()").decode('utf8')
+
         self.__set_sysname()
 
     @retry(PyboardError, tries=MAX_TRIES, delay=1, backoff=2, logger=logging.root)


### PR DESCRIPTION
1. telnet operation, if no user name given for login then just attach. I wrote a small server that works perfectly with the terminal and didn't want to add whole new program to support the function.

2. new version of micropython looks like when you attach / is a mount point and we probably want it to be /flash.  I modified the code to just ask for the current working directory on startup so that things just work for / or /flash.  maybe there is a better way here.