### PR TITLE
Colorama initialised first

### DIFF
--- a/mp/mpfshell.py
+++ b/mp/mpfshell.py
@@ -46,15 +46,16 @@ from mp.tokenizer import Tokenizer
 class MpFileShell(cmd.Cmd):
 
     def __init__(self, color=False, caching=False, reset=False):
-
-        cmd.Cmd.__init__(self)
+        if color:
+            colorama.init()
+            cmd.Cmd.__init__(self, stdout=colorama.initialise.wrapped_stdout)
+        else:
+            cmd.Cmd.__init__(self)
+        self.use_rawinput = False
 
         self.color = color
         self.caching = caching
         self.reset = reset
-
-        if self.color:
-            colorama.init()
 
         self.fe = None
         self.repl = None


### PR DESCRIPTION
Command-Prompt REPL initialised with color-supported stdout wrapper

Prevent Command-Prompt REPL from using the raw_input as it does not use the specified stdout to display prompt text.

This fixes erroneous color-display on the Windows platform. Native ANSI supporting platforms are unaffected as colorama init is implemented as noop on these systems.