### PR TITLE
Support installing the package inside a virtual environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ To install this tool for __Python 3__, execute the following:
     sudo pip3 install colorama
     sudo pip3 install websocket_client
     sudo python3 setup.py install
+    
+To install this tool in a [virtual environment](https://pypi.python.org/pypi/virtualenv), execute the following steps:
+
+    # Set up the virtual environment. Replace $python_global with the path to your Python executable. "venv" is the name of the subdirectory that will be created, and can be anything.
+    $python_global -m virtualenv venv
+	sudo pip install pyserial
+    sudo pip install colorama
+    sudo pip install websocket_client
+    # Tell disutils to use the current environment's Python executable,
+    # which will then be handled by virtualenv.
+    sudo python setup.py build -e "/usr/bin/env python"
+    sudo python setup.py install
 
 ## Known Issues
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python
 
 from mp import version
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
+
 
 setup(name='mpfshell',
       version=version.FULL,


### PR DESCRIPTION
The change to `setup.py` is necessary, but I'd have to look up the exact reason. Without the change, though, running this package using an environment-provided Python executable (which is what virtual environments do) is not possible on my system (testing on Python 2.7).

The README now includes step-by-step instructions on how to set this up.

This PR works well with https://github.com/wendlers/mpfshell/pull/39.