### PR TITLE
Make webrepl connection faster.

### DIFF
--- a/mp/conwebsock.py
+++ b/mp/conwebsock.py
@@ -54,9 +54,9 @@ class ConWebsock(ConBase, threading.Thread):
 
         self.timeout = 5.0
 
-        if b'Password:' in self.read(256, blocking=False):
+        if b'Password:' in self.read(10, blocking=False):
             self.ws.send(password + "\r")
-            if not b'WebREPL connected' in self.read(256, blocking=False):
+            if not b'WebREPL connected' in self.read(25, blocking=False):
                 raise ConError()
         else:
             raise ConError()


### PR DESCRIPTION
It seems we are unnecessarily reading more data from the server than necessary. This results in long wait time before the prompt shows up. I tested with the actual amount of data being read from the server, and it turns out that reading 256 bytes at both places is excessive.

Can we change to the actual numbers of bytes expected in both cases?

Let me know if there is a good reason for reading 256 bytes instead.