### PR TITLE
Change to setuptools, provide mpfshell entrypoint

### DIFF
--- a/mp/mpfexp.py
+++ b/mp/mpfexp.py
@@ -151,7 +151,7 @@ class MpFileExplorer(Pyboard):
         return os.path.join(self.dir, name)
 
     def __set_sysname(self):
-        self.sysname = self.eval("os.uname()[0]").decode('utf-8')
+        self.sysname = self.eval("uos.uname()[0]").decode('utf-8')
 
     def close(self):
 

--- a/mp/pyboard.py
+++ b/mp/pyboard.py
@@ -67,6 +67,9 @@ class Pyboard:
         while n > 0:
             self.con.read(n)
             n = self.con.inWaiting()
+        
+        # Wait for some time to fix error with D1 mini
+        time.sleep(0.5)
 
         if self.con.survives_soft_reset():
 

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
-
 from mp import version
-from distutils.core import setup
+from setuptools import setup
+
 
 setup(name='mpfshell',
       version=version.FULL,
-      description='A simple shell based file explorer for ESP8266 and WiPy Micropython devices.',
+      description='A simple shell based file explorer for ESP8266 and WiPy '
+                  'Micropython devices.',
       author='Stefan Wendler',
       author_email='sw@kaltpost.de',
       url='https://github.com/wendlers/mpfshell',
@@ -15,4 +16,9 @@ setup(name='mpfshell',
       scripts=['mpfshell'],
       keywords=['micropython', 'shell', 'file transfer', 'development'],
       classifiers=[],
-)
+      entry_points={
+        'console_scripts': [
+            'mpfshell=mp.mpfshell:main',
+        ]
+      },
+      )


### PR DESCRIPTION
Setuptools entry_points make mpfshell more convenient. You can now simply type `$ mpfshell` in the commandline and mpfshell will start. 