### PR TITLE
Import binascii for CircuitPython

### DIFF
--- a/mp/mpfexp.py
+++ b/mp/mpfexp.py
@@ -166,7 +166,8 @@ class MpFileExplorer(Pyboard):
     def setup(self):
 
         self.enter_raw_repl()
-        self.exec_("import os, sys, ubinascii")
+        self.exec_("import os, sys")
+        self.exec_("try:\n    import ubinascii\nexcept ImportError:\n    import binascii as ubinascii")
 
         # New version mounts files on /flash so lets set dir based on where we are in
         # filesystem.


### PR DESCRIPTION
I really like mpfshell but it no longer works with CircuitPython. There's an issue about this identifying the problem - https://github.com/adafruit/circuitpython/issues/1029. No fix in that issue yet and I needed it so tried the change here and it seems to work ok for both MicroPython and CircuitPython. 