### PR TITLE
Fixed window drive path match

### DIFF
--- a/mp/tokenizer.py
+++ b/mp/tokenizer.py
@@ -56,7 +56,7 @@ class Token(object):
 class Tokenizer(object):
     def __init__(self):
 
-        valid_fnchars = r"A-Za-z0-9_%#~@/\$!\*\.\+\-"
+        valid_fnchars = r"A-Za-z0-9_%#~@/\$!\*\.\+\-\:"
 
         tokens = [
             (r"[%s]+" % valid_fnchars, lambda scanner, token: Token(Token.STR, token)),


### PR DESCRIPTION
allow open in C: to execfile .py in D: .

![BR$ZWSF7_GN ~VB9M4$6IH](https://user-images.githubusercontent.com/32978053/55454036-e7cdcb00-5610-11e9-901e-331cb3d1eceb.png)

in mpfshell-lite(It was developed very aggressively)

![@JAUY~C`CWPED6X7EAH$7VB](https://user-images.githubusercontent.com/32978053/55454052-fc11c800-5610-11e9-9b1e-c5c07798441f.png)
