### PR TITLE
fix: Remove second argument from on_error and on_message (conwebsock.py)

### DIFF
--- a/mp/conwebsock.py
+++ b/mp/conwebsock.py
@@ -72,7 +72,7 @@ class ConWebsock(ConBase, threading.Thread):
     def __del__(self):
         self.close()
 
-    def on_message(self, ws, message):
+    def on_message(self, message):
         self.fifo.extend(message)
 
         try:
@@ -80,7 +80,7 @@ class ConWebsock(ConBase, threading.Thread):
         except:
             pass
 
-    def on_error(self, ws, error):
+    def on_error(self, error):
         logging.error("websocket error: %s" % error)
 
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyserial ~= 3.4
 colorama ~= 0.3.6
-websocket_client ~= 0.35.0
+websocket_client ~= 0.56.0


### PR DESCRIPTION
This fixes ws connections to ESP8266 boards with more recent versions of websocket_client.