### PR TITLE
Save/restore current path before/after entering REPL

### DIFF
--- a/mp/mpfshell.py
+++ b/mp/mpfshell.py
@@ -633,6 +633,7 @@ class MpFileShell(cmd.Cmd):
                 self.fe.cache = {}
 
             self.fe.setup()
+            self.__set_prompt_path()
             print("")
 
     def do_mpyc(self, args):

--- a/mp/mpfshell.py
+++ b/mp/mpfshell.py
@@ -613,6 +613,7 @@ class MpFileShell(cmd.Cmd):
             else:
                 self.repl.serial = self.fe.con
 
+            pwd = self.fe.pwd()
             self.fe.teardown()
             self.repl.start()
 
@@ -633,7 +634,13 @@ class MpFileShell(cmd.Cmd):
                 self.fe.cache = {}
 
             self.fe.setup()
-            self.__set_prompt_path()
+            try:
+                self.fe.cd(pwd)
+            except RemoteIOError as e:
+                # Working directory does not exist anymore
+                self.__error(str(e))
+            finally:
+                self.__set_prompt_path()
             print("")
 
     def do_mpyc(self, args):


### PR DESCRIPTION
Without these changes, mpfshell returns to the fs root, i.e. /, when returning from REPL, but still displays the original path from before REPL in the prompt. One commit makes sure the correct path is displayed in the prompt when returning from REPL. The other commit restores the path from before REPL, if it still exists.