### PR TITLE
Better handling of timeout on serial line.

### DIFF
--- a/mp/conserial.py
+++ b/mp/conserial.py
@@ -30,11 +30,11 @@ from serial import Serial
 
 
 class ConSerial(ConBase):
-    def __init__(self, port, baudrate=115200, reset=False):
+    def __init__(self, port, baudrate=115200, reset=False, timeout=1):
         ConBase.__init__(self)
 
         try:
-            self.serial = Serial(port, baudrate=baudrate, interCharTimeout=1)
+            self.serial = Serial(port, baudrate=baudrate, interCharTimeout=1, timeout=timeout)
 
             if reset:
                 logging.info("Hard resetting device at port: %s" % port)

--- a/mp/mpfexp.py
+++ b/mp/mpfexp.py
@@ -113,7 +113,8 @@ class MpFileExplorer(Pyboard):
             else:
                 baudrate = 115200
 
-            con = ConSerial(port=port, baudrate=baudrate, reset=self.reset)
+            timeout = 0.1 # 100 ms timeout in serial.read()
+            con = ConSerial(port=port, baudrate=baudrate, reset=self.reset, timeout=timeout)
 
         elif proto.strip(" ") == "tn":
 

--- a/mp/pyboard.py
+++ b/mp/pyboard.py
@@ -36,24 +36,20 @@ class Pyboard:
 
     def read_until(self, min_num_bytes, ending, timeout=10, data_consumer=None):
 
-        data = self.con.read(min_num_bytes)
+        to_read = max(min_num_bytes, len(ending))
+        data = self.con.read(to_read)
         if data_consumer:
             data_consumer(data)
-        timeout_count = 0
+        time_start = time.monotonic()
         while True:
             if data.endswith(ending):
                 break
-            elif self.con.inWaiting() > 0:
-                new_data = self.con.read(1)
-                data = data + new_data
-                if data_consumer:
-                    data_consumer(new_data)
-                timeout_count = 0
-            else:
-                timeout_count += 1
-                if timeout is not None and timeout_count >= 100 * timeout:
-                    break
-                time.sleep(0.01)
+            new_data = self.con.read(1)
+            data = data + new_data
+            if data_consumer:
+                data_consumer(new_data)
+            if time.monotonic() - time_start > timeout:
+                break
         return data
 
     def enter_raw_repl(self):


### PR DESCRIPTION
The current implementation uses the default timeout of ConSerial(). This PR makes the timeout configurable.