### PR TITLE
fixed crash of "exec code_with_mistakes"

### DIFF
--- a/mp/mpfshell.py
+++ b/mp/mpfshell.py
@@ -571,7 +571,7 @@ class MpFileShell(cmd.Cmd):
                 ret = self.fe.follow(None, data_consumer)
 
                 if len(ret[-1]):
-                    self.__error(ret[-1])
+                    self.__error(ret[-1].decode("utf-8"))
 
             except IOError as e:
                 self.__error(str(e))


### PR DESCRIPTION
The exec function (e.g. exec int('a')) fails with 'TypeError: can only concatenate str (not "bytes") to str' and crashes Mpfshell.
The crash is caused by code in __error function:
`print("\n" + colorama.Fore.RED + msg + colorama.Fore.RESET + "\n")`.
It needs str not bytes.