### PR TITLE
Running scripts under Miniconda with Windows

### DIFF
--- a/mp/mpfshell.py
+++ b/mp/mpfshell.py
@@ -812,6 +812,9 @@ def main():
 
     elif args.script is not None:
 
+        if platform.system() == "Windows":
+            mpfs.use_rawinput = True
+            
         f = open(args.script, "r")
         script = ""
 


### PR DESCRIPTION
Trying to run a script when inside an Anaconda/Miniconda virtual environment on windows10, the script would refuse to run.
This tweak made it behave.
I'm not sure if there are other consequences to this inclusion though: it might break under some other virtual environment, or non-virtual environment.