### PR TITLE
Fix #97

### DIFF
--- a/mp/conwebsock.py
+++ b/mp/conwebsock.py
@@ -72,7 +72,7 @@ class ConWebsock(ConBase, threading.Thread):
     def __del__(self):
         self.close()
 
-    def on_message(self, message):
+    def on_message(self, ws, message):
         self.fifo.extend(message)
 
         try:
@@ -80,7 +80,7 @@ class ConWebsock(ConBase, threading.Thread):
         except:
             pass
 
-    def on_error(self, error):
+    def on_error(self, ws, error):
         logging.error("websocket error: %s" % error)
 
         try:

--- a/mp/mpfexp.py
+++ b/mp/mpfexp.py
@@ -463,7 +463,7 @@ class MpFileExplorer(Pyboard):
             return_code = subprocess.call("mpy-cross -o %s %s" % (dst, src), shell=True)
 
         if return_code != 0:
-            raise IOError("Filed to compile: %s" % src)
+            raise IOError("Failed to compile: %s" % src)
 
 
 class MpFileExplorerCaching(MpFileExplorer):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyserial ~= 3.4
 colorama ~= 0.3.6
-websocket_client ~= 0.56.0
+websocket_client ~= 0.35.0

--- a/tests/ontarget/conftest.py
+++ b/tests/ontarget/conftest.py
@@ -73,7 +73,7 @@ def mpsetup(request):
             "pytest.py",
             """
 def rm(path):
-    import os
+    import uos as os
     files = os.listdir(path)
     for f in files:
         if f not in ['boot.py', 'port_config.py']:

--- a/tests/ontarget/conftest.py
+++ b/tests/ontarget/conftest.py
@@ -88,7 +88,7 @@ def rm(path):
         )
 
         fe.exec_("import pytest")
-        fe.exec_("pytest.rm(os.getcwd())")
+        fe.exec_("pytest.rm('.')")
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Blindly reverting after git bisect; I've not checked why it was thought that the semantics of ConWebsock had changed.

Test suite passes for websocket.  Flaky failure of test_bigfile over serial on my hardware, but unrelated to this commit.

Additionally fixes two bugs in the testsuite:
- uos not os in conftest
- os.getcwd() fails as os not imported, but is equivalent to "." anyhow

Incidentally your testsuite has inspired me to run pytest locally and command behaviour on the hardware as a general workaround for testing being quite hard in uP.