### PR TITLE
Add telnetlib-313-and-up for Python versions >= 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyserial ~= 3.4
 colorama ~= 0.3.6
 websocket_client ~= 0.35.0
+telnetlib-313-and-up; python_version >= '3.13'


### PR DESCRIPTION
This allows usage with Python 3.13 and up since `telnetlib` was removed in Python 3.13.

Closes #114

Thanks to [gauthier12](https://github.com/gauthier12) for [his idea to use this workaround](https://github.com/wendlers/mpfshell/issues/114#issuecomment-2578729929).